### PR TITLE
Added tests

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,7 @@ author = "George"
 # The short X.Y version
 version = ""
 # The full version, including alpha/beta/rc tags
-release = "0.1.8"
+release = "0.1.9"
 
 
 # -- General configuration ---------------------------------------------------

--- a/qval/__init__.py
+++ b/qval/__init__.py
@@ -93,4 +93,4 @@ from .exceptions import InvalidQueryParamException, APIException
 from .validator import Validator
 
 
-__version__ = "0.1.8"
+__version__ = "0.1.9"

--- a/qval/qval.py
+++ b/qval/qval.py
@@ -54,6 +54,20 @@ class QueryParamValidator(AbstractContextManager):
         self._params: Dict[str, Validator] = {k: Validator() for k in self.result}
         self._params.update(validators or {})
 
+    def apply_to_request(self, request: fwk.Request) -> "QueryParamValidator":
+        """
+        Applies current validation settings to a new request.
+
+        :param request: new request instance
+        :return: new :class:`QueryParamValidator` instance
+        """
+        return self.__class__(
+            request,
+            self._factories,
+            self._params,
+            self._box_all
+        )
+
     @property
     def query_params(self) -> Dict[str, str]:
         """
@@ -322,7 +336,7 @@ def qval(
             elif isinstance(args[0], fwk.RequestType):
                 # And construct request from dict
                 request = args[0] = utils.make_request(args[0])
-            elif isinstance(args[1], fwk.RequestType):
+            elif len(args) > 1 and isinstance(args[1], fwk.RequestType):
                 request = args[1] = utils.make_request(args[1])
             else:
                 raise ValueError(

--- a/qval/qval.py
+++ b/qval/qval.py
@@ -61,12 +61,7 @@ class QueryParamValidator(AbstractContextManager):
         :param request: new request instance
         :return: new :class:`QueryParamValidator` instance
         """
-        return self.__class__(
-            request,
-            self._factories,
-            self._params,
-            self._box_all
-        )
+        return self.__class__(request, self._factories, self._params, self._box_all)
 
     @property
     def query_params(self) -> Dict[str, str]:

--- a/tests/test_make_request_wrapper.py
+++ b/tests/test_make_request_wrapper.py
@@ -23,6 +23,7 @@ def make_request_wrapper(f):
     def wrapper(request):
         wrapper.__list__.append(request)
         return f(request)
+
     wrapper.__list__ = []
     return wrapper
 

--- a/tests/test_make_request_wrapper.py
+++ b/tests/test_make_request_wrapper.py
@@ -1,0 +1,30 @@
+import os
+from importlib import reload, import_module
+
+import pytest
+
+
+@pytest.fixture()
+def isolation():
+    os.environ["DJANGO_SETTINGS_MODULE"] = "tests.test_make_request_wrapper"
+    yield None
+    del os.environ["DJANGO_SETTINGS_MODULE"]
+
+
+def test_make_request_wrapper(isolation):
+    _ = reload(import_module("qval.framework_integration"))
+    make_request = reload(import_module("qval.utils")).make_request
+    r = {"param": "value"}
+    _ = make_request(r)
+    assert make_request.__list__[0] == r
+
+
+def make_request_wrapper(f):
+    def wrapper(request):
+        wrapper.__list__.append(request)
+        return f(request)
+    wrapper.__list__ = []
+    return wrapper
+
+
+QVAL_MAKE_REQUEST_WRAPPER = make_request_wrapper

--- a/tests/test_qval_decorator.py
+++ b/tests/test_qval_decorator.py
@@ -74,6 +74,29 @@ def test_params_validated():
         assert e.value.status_code == HTTP_400_BAD_REQUEST
 
 
+def test_qval_requires_params():
+    with pytest.raises(TypeError):
+        @qval
+        def sample():
+            pass
+
+
+def test_qval_requires_request_argument():
+    @qval({})
+    def sample(request):
+        pass
+
+    with pytest.raises(ValueError):
+        sample(object())
+
+    @qval({})
+    def multi_param(first, second, request):
+        pass
+
+    with pytest.raises(ValueError):
+        multi_param(object(), list(), {})
+
+
 # Curries qval with a static request (in this case)
 # Useful in frameworks with global request classes (e.g. Flask)
 def get_curried_qval():

--- a/tests/test_qval_decorator.py
+++ b/tests/test_qval_decorator.py
@@ -76,6 +76,7 @@ def test_params_validated():
 
 def test_qval_requires_params():
     with pytest.raises(TypeError):
+
         @qval
         def sample():
             pass

--- a/tests/test_qval_validator_class.py
+++ b/tests/test_qval_validator_class.py
@@ -1,0 +1,65 @@
+import pytest
+
+from qval import InvalidQueryParamException
+from qval.utils import make_request
+from qval.qval import QueryParamValidator
+from tests.crossframework import builder
+
+
+def test_chain_validators():
+    request = {
+        "num": "42",
+        "num2": "-10",
+        "num3": "3.14",
+        "power": "16",
+        "power2": "25",
+        "new_param": "2.79",
+    }
+    # fmt: off
+    factories = {
+        "num": int,
+        "num2": int,
+        "num3": float,
+        "power": int,
+        "power2": lambda x: float(x) ** 0.5
+    }
+    # fmt: on
+
+    qval = (
+        QueryParamValidator(make_request(request), factories)
+            .check("power", lambda x: (x ** 0.5).is_integer())
+            .check("power2", float.is_integer)
+            .eq("num", 42)
+            .gt("num", 41)
+            .lt("num2", 0)
+            .nonzero("num3")
+            .positive("power")
+    )
+    qval.add_predicate(
+        "new_param",
+        lambda x: float(x) not in (float("inf"), float("-inf"))
+    )
+    for r in builder.iterbuild(request):
+        params = qval.apply_to_request(r)
+        with params as p:
+            assert p.num == 42
+            assert p.num2 == -10
+            assert p.num3 == 3.14
+            assert p.power == 16
+            assert p.power2 == 5
+            assert p.new_param == "2.79"
+
+
+    bad_examples = {
+        "num": "0",  # is not equal to 42
+        "num2": "1",  # is greater than zero
+        "num3": "0",  # is equal to zero
+        "power": "-64",  # is not positive
+        "power2": "24",  # is not a perfect square
+        "new_param": "inf",  # is an infinity
+    }
+
+    for r in builder.iterbuild(bad_examples):
+        params = qval.apply_to_request(r)
+        with pytest.raises(InvalidQueryParamException), params:
+            pass

--- a/tests/test_qval_validator_class.py
+++ b/tests/test_qval_validator_class.py
@@ -27,17 +27,16 @@ def test_chain_validators():
 
     qval = (
         QueryParamValidator(make_request(request), factories)
-            .check("power", lambda x: (x ** 0.5).is_integer())
-            .check("power2", float.is_integer)
-            .eq("num", 42)
-            .gt("num", 41)
-            .lt("num2", 0)
-            .nonzero("num3")
-            .positive("power")
+        .check("power", lambda x: (x ** 0.5).is_integer())
+        .check("power2", float.is_integer)
+        .eq("num", 42)
+        .gt("num", 41)
+        .lt("num2", 0)
+        .nonzero("num3")
+        .positive("power")
     )
     qval.add_predicate(
-        "new_param",
-        lambda x: float(x) not in (float("inf"), float("-inf"))
+        "new_param", lambda x: float(x) not in (float("inf"), float("-inf"))
     )
     for r in builder.iterbuild(request):
         params = qval.apply_to_request(r)
@@ -48,7 +47,6 @@ def test_chain_validators():
             assert p.power == 16
             assert p.power2 == 5
             assert p.new_param == "2.79"
-
 
     bad_examples = {
         "num": "0",  # is not equal to 42


### PR DESCRIPTION
Added tests for `qval.utils` module and `qval.qval.QueryParamValidator`.
Fixed bug in `qval.qval()`, it used to raise `IndexError()` if provided to the view argument (i.e only 1) is not a request-like. 